### PR TITLE
feat(stream): add write_now and pipe::write_with_handle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ uv::timer timer(loop);
 - Reserve `try_*` for non-throwing variants that return `std::error_code` or an equivalent explicit status channel.
 - Name synchronous immediate libuv operations `*_now()` even when the libuv function uses `try`, such as `send_now()` or `write_now()`.
 - Use typed result objects when an immediate libuv return value mixes payload and status, such as byte counts plus `UV_EAGAIN`.
+- Use C++20 concepts for public templates that depend on structural API contracts, such as stream-like handles or callback invocability.
 - Prefer references in callbacks when null is not valid.
 - Report asynchronous completion through `uv::result` or typed result objects.
 - Throw `uv::error` for immediate submission failures in the primary low-level API.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,15 @@ uv::timer timer(loop);
 - Do not make handles copyable or movable.
 - Do not store wrapper internals in libuv `data`; `data` belongs to application code.
 - Keep raw libuv access explicit through named helpers such as `native()`, `native_handle()`, and `native_stream()`.
+- Do not add implicit conversions to raw libuv pointers or borrowed view types.
+- Produce borrowed views through explicit `.view()` functions, such as `timer.view()` or `buffer.view()`.
+- Reserve `try_*` for non-throwing variants that return `std::error_code` or an equivalent explicit status channel.
+- Name synchronous immediate libuv operations `*_now()` even when the libuv function uses `try`, such as `send_now()` or `write_now()`.
+- Use typed result objects when an immediate libuv return value mixes payload and status, such as byte counts plus `UV_EAGAIN`.
 - Prefer references in callbacks when null is not valid.
 - Report asynchronous completion through `uv::result` or typed result objects.
 - Throw `uv::error` for immediate submission failures in the primary low-level API.
+- Use `std::chrono` for public duration values; keep counters as integer counts.
 - Keep asynchronous lifetime visible through handle/request ownership.
 - Keep low-level wrappers allocation-free unless the API explicitly owns operation state.
 - Do not let exceptions escape from libuv C callbacks.
@@ -47,6 +53,7 @@ Read these before changing public API shape or callback/lifetime behavior:
 
 - `docs/design/architecture.md`
 - `docs/design/api-principles.md`
+- `docs/design/api-policy-decisions.md`
 - `docs/design/callback-strategy.md`
 - `docs/design/error-handling-strategy.md`
 - `docs/design/ownership-strategy.md`

--- a/docs/design/api-policy-decisions.md
+++ b/docs/design/api-policy-decisions.md
@@ -1,0 +1,135 @@
+# API Policy Decisions
+
+This file records small but important API policy decisions that should stay
+consistent as uvpp grows. It is intentionally more concrete than the general
+API principles.
+
+## `try_*` Names
+
+Reserve `try_*` for non-throwing variants of APIs that would otherwise throw on
+immediate libuv failure.
+
+`try_*` functions should return `std::error_code` or a similarly explicit
+non-throwing status channel, and should not throw for normal immediate failure.
+
+Example:
+
+```cpp
+std::error_code close_error = loop.try_close();
+```
+
+Do not use `try_*` just because the underlying libuv function contains `try` in
+its name.
+
+## Immediate Non-Blocking Operations
+
+When libuv exposes a synchronous "try now" operation, name the uvpp wrapper
+`*_now()`.
+
+Examples:
+
+```cpp
+auto sent = udp.send_now(buffer, address);
+auto written = stream.write_now(buffer);
+```
+
+These functions do not own asynchronous state, do not take request objects, and
+do not take callbacks.
+
+If a non-blocking "nothing happened" status is part of the normal control flow
+for that operation, model it explicitly in a typed result object instead of
+throwing. For example, an operation based on `uv_try_write()` should expose a
+`would_block()` branch for `UV_EAGAIN`.
+
+## Typed Result Objects
+
+Use a typed result object when a libuv return value contains meaningful payload
+and status in the same integer.
+
+Examples:
+
+- stream reads: positive values are byte counts, `UV_EOF` is a normal EOF branch;
+- synchronous non-blocking writes: positive values are byte counts, `UV_EAGAIN`
+  means the operation would block.
+
+Typed result objects should make ordinary branches visible:
+
+```cpp
+if (result.would_block()) {
+  return;
+}
+
+if (result.has_error()) {
+  auto ec = result.error_code();
+  return;
+}
+
+auto bytes = result.bytes_written();
+```
+
+Expose raw status for interop when useful, but avoid forcing callers to decode
+libuv sentinel values for common control flow.
+
+## Borrowed Views
+
+Borrowed views must be produced by named functions, not implicit conversion
+operators.
+
+Examples:
+
+```cpp
+uv::handle_view handle = timer.view();
+uv::buffer_view buffer = storage.view();
+```
+
+The `.view()` spelling makes the ownership relationship visible: the returned
+object does not own the underlying native handle, bytes, or storage.
+
+Do not add implicit conversions from owning or address-stable wrappers to
+borrowed views such as `handle_view`.
+
+## Native Access
+
+Raw libuv access stays explicit through named helpers:
+
+```cpp
+uv_tcp_t* raw = tcp.native();
+uv_stream_t* stream = tcp.native_stream();
+uv_handle_t* handle = tcp.native_handle();
+```
+
+Do not add implicit conversion operators to raw libuv pointers.
+
+## Chrono For Durations
+
+Use `std::chrono` for durations in public APIs.
+
+If libuv represents a timeout with a sentinel value, model the sentinel in the
+type instead of leaking it directly when practical. For example,
+`loop.backend_timeout()` returns `std::optional<std::chrono::milliseconds>`,
+where `std::nullopt` represents an infinite wait.
+
+Counters remain integer counts. Do not wrap event counts or loop iteration
+counts in duration types.
+
+## Async Lifetime Visibility
+
+If an operation outlives the initiating call, the owner of the operation state
+must be clear in the function signature.
+
+Low-level request-shaped API:
+
+```cpp
+uv::write_request request;
+stream.write(request, buffer, callback);
+```
+
+Synchronous immediate API:
+
+```cpp
+auto result = stream.write_now(buffer);
+```
+
+Do not hide request lifetime behind a low-level convenience that accepts only
+data and a callback unless the API name and documentation make ownership
+explicit.

--- a/docs/design/api-policy-decisions.md
+++ b/docs/design/api-policy-decisions.md
@@ -100,6 +100,32 @@ uv_handle_t* handle = tcp.native_handle();
 
 Do not add implicit conversion operators to raw libuv pointers.
 
+## Public Template Constraints
+
+Use C++20 concepts for public templates that depend on structural API
+contracts.
+
+Examples:
+
+```cpp
+template<class T>
+concept stream_handle = requires(T& handle) {
+  { handle.native_stream() } -> std::convertible_to<uv_stream_t*>;
+};
+
+template<stream_handle Client>
+void accept(Client& client);
+```
+
+Good candidates are APIs where the template argument represents a user-visible
+category, such as stream-like handles, callbacks passed to `walk()`, or wrapper
+types passed to `handle_view::as<T>()`.
+
+Do not add constraints mechanically to every implementation template. Private
+helpers such as submit lambdas, result factories, and local getter utilities can
+remain unconstrained when their use is obvious and diagnostics are already
+local.
+
 ## Chrono For Durations
 
 Use `std::chrono` for durations in public APIs.

--- a/docs/design/api-principles.md
+++ b/docs/design/api-principles.md
@@ -1,5 +1,8 @@
 # API Principles
 
+For concrete naming and result-shape decisions that must stay consistent across
+future API additions, also read [API policy decisions](api-policy-decisions.md).
+
 ## API Shape
 
 uvpp v2 should feel like a C++ library that happens to use libuv, not a direct transliteration of libuv naming and memory conventions.

--- a/docs/design/error-handling-strategy.md
+++ b/docs/design/error-handling-strategy.md
@@ -12,6 +12,10 @@ The grammar is:
 - `uv::result` exposes `status()` and `error_code()`, not `error()`;
 - v2 does not use `result<void>` in the low-level API.
 
+See [API policy decisions](api-policy-decisions.md) for the related naming rule:
+libuv "try now" operations should use `*_now()` in uvpp rather than consuming
+the `try_*` prefix.
+
 ## Error Type
 
 Use a small `uv::error` type for exceptions and expose `std::error_code` for non-throwing APIs.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -4,6 +4,7 @@ These documents describe uvpp's API and implementation strategy. They are primar
 
 - [Architecture](architecture.md): storage model, wrapper hierarchy, native interop, and repository layout.
 - [API principles](api-principles.md): public API shape, naming, native access, user data, and value types.
+- [API policy decisions](api-policy-decisions.md): concrete naming and result-shape policies for future API additions.
 - [Callback strategy](callback-strategy.md): runtime callbacks, static callbacks, callback slots, trampolines, and exception boundaries.
 - [Error handling strategy](error-handling-strategy.md): immediate failures, async completion results, EOF, and callback failure policy.
 - [Ownership strategy](ownership-strategy.md): handle lifetime, request lifetime, buffers, user data, loop ownership, and deallocation rules.

--- a/include/uvpp/core/loop.hpp
+++ b/include/uvpp/core/loop.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <concepts>
 #include <memory>
 #include <optional>
 #include <system_error>
@@ -83,6 +84,7 @@ public:
   // Handles not created by uvpp can be safely observed; use handle_view::as<T>()
   // only for handles you know were created by uvpp.
   template<class F>
+    requires std::invocable<F&, handle_view>
   void walk(F &&callback);
 
   // Collect all handles into a vector. Suitable for range-based for and
@@ -161,6 +163,7 @@ public:
   void fork() { view().fork(); }
 
   template<class F>
+    requires std::invocable<F&, handle_view>
   void walk(F &&callback) { view().walk(std::forward<F>(callback)); }
 
   std::vector<handle_view> handles() { return view().handles(); }
@@ -174,6 +177,7 @@ inline loop_view default_loop() noexcept {
 }
 
 template<class F>
+  requires std::invocable<F&, handle_view>
 void loop_view::walk(F &&callback) {
   auto thunk = [&callback](handle_view h) {
     callback(h);

--- a/include/uvpp/handles/handle_view.hpp
+++ b/include/uvpp/handles/handle_view.hpp
@@ -1,8 +1,22 @@
 #pragma once
 
+#include <concepts>
+
 #include <uv.h>
 
 namespace uv {
+
+namespace detail {
+
+template<class T>
+concept native_handle_recoverable =
+  requires { typename T::raw_type; } &&
+  requires(typename T::raw_type *raw, const typename T::raw_type *const_raw) {
+    { T::from_native(raw) } -> std::same_as<T&>;
+    { T::from_native(const_raw) } -> std::same_as<const T&>;
+  };
+
+} // namespace detail
 
 // Non-owning view of any uv_handle_t*, including handles not created by uvpp.
 // Provides safe access to common handle operations.
@@ -29,11 +43,13 @@ public:
   // Recovers the uvpp object from the handle pointer.
   // UNSAFE: only valid if this handle was created by uvpp as a T.
   template<class T>
+    requires detail::native_handle_recoverable<T>
   T &as() noexcept {
     return T::from_native(reinterpret_cast<typename T::raw_type *>(raw_));
   }
 
   template<class T>
+    requires detail::native_handle_recoverable<T>
   const T &as() const noexcept {
     return T::from_native(reinterpret_cast<const typename T::raw_type *>(raw_));
   }

--- a/include/uvpp/handles/pipe.hpp
+++ b/include/uvpp/handles/pipe.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <span>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -91,6 +92,29 @@ namespace uv {
 
     void chmod(pipe_chmod_flag flag) {
       chmod(static_cast<int>(flag));
+    }
+
+    template<class SendHandle>
+      requires requires(SendHandle &h) { h.native_stream(); }
+    void write_with_handle(write_request &request, std::span<const buffer_view> buffers,
+                           SendHandle &send_handle, write_request::callback callback) {
+      detail::submit_request(request, std::move(callback), [&] {
+        return uv_write2(request.native(), native_stream(),
+                         reinterpret_cast<const uv_buf_t *>(buffers.data()),
+                         static_cast<unsigned int>(buffers.size()),
+                         send_handle.native_stream(),
+                         write_request::trampoline);
+      });
+    }
+
+    template<class SendHandle>
+      requires requires(SendHandle &h) { h.native_stream(); }
+    write_now_result write_with_handle_now(std::span<const buffer_view> buffers,
+                                           SendHandle &send_handle) noexcept {
+      return write_now_result{uv_try_write2(native_stream(),
+        reinterpret_cast<const uv_buf_t *>(buffers.data()),
+        static_cast<unsigned int>(buffers.size()),
+        send_handle.native_stream())};
     }
 
   private:

--- a/include/uvpp/handles/pipe.hpp
+++ b/include/uvpp/handles/pipe.hpp
@@ -95,7 +95,7 @@ namespace uv {
     }
 
     template<class SendHandle>
-      requires requires(SendHandle &h) { h.native_stream(); }
+      requires requires(SendHandle &h) { { h.native_stream() } -> std::convertible_to<uv_stream_t *>; }
     void write_with_handle(write_request &request, std::span<const buffer_view> buffers,
                            SendHandle &send_handle, write_request::callback callback) {
       detail::submit_request(request, std::move(callback), [&] {
@@ -108,7 +108,7 @@ namespace uv {
     }
 
     template<class SendHandle>
-      requires requires(SendHandle &h) { h.native_stream(); }
+      requires requires(SendHandle &h) { { h.native_stream() } -> std::convertible_to<uv_stream_t *>; }
     write_now_result write_with_handle_now(std::span<const buffer_view> buffers,
                                            SendHandle &send_handle) noexcept {
       return write_now_result{uv_try_write2(native_stream(),

--- a/include/uvpp/handles/pipe.hpp
+++ b/include/uvpp/handles/pipe.hpp
@@ -94,8 +94,7 @@ namespace uv {
       chmod(static_cast<int>(flag));
     }
 
-    template<class SendHandle>
-      requires requires(SendHandle &h) { { h.native_stream() } -> std::convertible_to<uv_stream_t *>; }
+    template<stream_handle SendHandle>
     void write_with_handle(write_request &request, std::span<const buffer_view> buffers,
                            SendHandle &send_handle, write_request::callback callback) {
       detail::submit_request(request, std::move(callback), [&] {
@@ -107,8 +106,7 @@ namespace uv {
       });
     }
 
-    template<class SendHandle>
-      requires requires(SendHandle &h) { { h.native_stream() } -> std::convertible_to<uv_stream_t *>; }
+    template<stream_handle SendHandle>
     write_now_result write_with_handle_now(std::span<const buffer_view> buffers,
                                            SendHandle &send_handle) noexcept {
       return write_now_result{uv_try_write2(native_stream(),

--- a/include/uvpp/handles/stream.hpp
+++ b/include/uvpp/handles/stream.hpp
@@ -42,6 +42,28 @@ namespace uv {
     buffer_view buffer_;
   };
 
+  class write_now_result {
+  public:
+    explicit write_now_result(int value) noexcept : value_{value} {}
+
+    bool ok()          const noexcept { return value_ >= 0; }
+    bool would_block() const noexcept { return value_ == UV_EAGAIN; }
+    bool has_error()   const noexcept { return value_ < 0 && value_ != UV_EAGAIN; }
+
+    std::size_t bytes_written() const noexcept {
+      return ok() ? static_cast<std::size_t>(value_) : 0;
+    }
+
+    int raw() const noexcept { return value_; }
+
+    std::error_code error_code() const noexcept {
+      return has_error() ? make_error_code(value_) : std::error_code{};
+    }
+
+  private:
+    int value_;
+  };
+
   template<class Derived, class Raw>
   class stream : public basic_handle<Derived, Raw> {
   public:
@@ -120,7 +142,7 @@ namespace uv {
     void write(write_request &request, std::span<const buffer_view> buffers, write_request::callback callback) {
       detail::submit_request(request, std::move(callback), [&] {
         return uv_write(request.native(), native_stream(), reinterpret_cast<const uv_buf_t *>(buffers.data()),
-                        static_cast<unsigned int>(buffers.size()), &stream::write_trampoline);
+                        static_cast<unsigned int>(buffers.size()), write_request::trampoline);
       });
     }
 
@@ -132,7 +154,7 @@ namespace uv {
       auto raw = uv_buf_init(const_cast<char *>(reinterpret_cast<const char *>(bytes.data())),
                              static_cast<unsigned int>(bytes.size()));
       detail::submit_request(request, std::move(callback), [&] {
-        return uv_write(request.native(), native_stream(), &raw, 1, &stream::write_trampoline);
+        return uv_write(request.native(), native_stream(), &raw, 1, write_request::trampoline);
       });
     }
 
@@ -142,6 +164,22 @@ namespace uv {
                      static_cast<unsigned int>(buffers.size()), [](uv_write_t *raw, int status) noexcept {
         detail::invoke_static_callback<Callback>(write_request::from_native(raw), result{status});
       }));
+    }
+
+    write_now_result write_now(std::span<const buffer_view> buffers) noexcept {
+      return write_now_result{uv_try_write(native_stream(),
+        reinterpret_cast<const uv_buf_t *>(buffers.data()),
+        static_cast<unsigned int>(buffers.size()))};
+    }
+
+    write_now_result write_now(const buffer_view &buf) noexcept {
+      return write_now(std::span<const buffer_view>{&buf, 1});
+    }
+
+    write_now_result write_now(std::span<const std::byte> bytes) noexcept {
+      auto raw = uv_buf_init(const_cast<char *>(reinterpret_cast<const char *>(bytes.data())),
+                             static_cast<unsigned int>(bytes.size()));
+      return write_now_result{uv_try_write(native_stream(), &raw, 1)};
     }
 
   private:
@@ -175,10 +213,6 @@ namespace uv {
       if (base.read_callback_) {
         detail::invoke_callback(base.read_callback_, self, read_result{nread, buf});
       }
-    }
-
-    static void write_trampoline(uv_write_t *raw, int status) noexcept {
-      write_request::from_native(raw).invoke(status);
     }
 
     static void shutdown_trampoline(uv_shutdown_t *raw, int status) noexcept {

--- a/include/uvpp/handles/stream.hpp
+++ b/include/uvpp/handles/stream.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <concepts>
 #include <cstddef>
 #include <functional>
 #include <span>
@@ -64,6 +65,11 @@ namespace uv {
     int value_;
   };
 
+  template<class T>
+  concept stream_handle = requires(T &handle) {
+    { handle.native_stream() } -> std::convertible_to<uv_stream_t *>;
+  };
+
   template<class Derived, class Raw>
   class stream : public basic_handle<Derived, Raw> {
   public:
@@ -95,7 +101,7 @@ namespace uv {
       throw_if_error(uv_stream_set_blocking(native_stream(), enable ? 1 : 0));
     }
 
-    template<class Client>
+    template<stream_handle Client>
     void accept(Client &client) {
       throw_if_error(uv_accept(native_stream(), client.native_stream()));
     }

--- a/include/uvpp/requests/write.hpp
+++ b/include/uvpp/requests/write.hpp
@@ -28,6 +28,10 @@ namespace uv {
       }
     }
 
+    static void trampoline(uv_write_t *raw, int status) noexcept {
+      from_native(raw).invoke(status);
+    }
+
   private:
     callback callback_{};
   };

--- a/tests/test-layout.cpp
+++ b/tests/test-layout.cpp
@@ -4,6 +4,14 @@
 #include "gtest/gtest.h"
 #include "uvpp/uv.hpp"
 
+static_assert(uv::stream_handle<uv::tcp>);
+static_assert(uv::stream_handle<uv::pipe>);
+static_assert(uv::stream_handle<uv::tty>);
+static_assert(!uv::stream_handle<uv::timer>);
+
+static_assert(uv::detail::native_handle_recoverable<uv::timer>);
+static_assert(!uv::detail::native_handle_recoverable<int>);
+
 TEST(Uvpp2Layout, reconstructsHandlesFromNativePointers) {
   static_assert(std::is_standard_layout_v<uv::async::native_storage>);
   static_assert(std::is_standard_layout_v<uv::check::native_storage>);

--- a/tests/test-loop.cpp
+++ b/tests/test-loop.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <chrono>
+#include <concepts>
 #include <ranges>
 #include <type_traits>
 #include <vector>
@@ -22,7 +23,14 @@ void record_handle_type(uv::handle_view h) {
   }
 }
 
+struct invalid_walk_callback {
+  void operator()(int) const {}
+};
+
 } // namespace
+
+static_assert(std::invocable<decltype(record_handle_type)&, uv::handle_view>);
+static_assert(!std::invocable<invalid_walk_callback&, uv::handle_view>);
 
 // ---------------------------------------------------------------------------
 // backend_fd / backend_timeout

--- a/tests/test-pipe.cpp
+++ b/tests/test-pipe.cpp
@@ -167,7 +167,7 @@ TEST(Uvpp2Pipe, writeWithHandleSendsStreamOverIpc) {
     srv.accept(*accepted);
     srv.close();
 
-    accepted->read_start(pipe_alloc, [&, accepted](uv::pipe &ipc, uv::read_result read) {
+    accepted->read_start(pipe_alloc, [&](uv::pipe &ipc, uv::read_result read) {
       if (read.eof()) {
         ipc.close([](uv::pipe &p) { delete &p; });
         return;

--- a/tests/test-pipe.cpp
+++ b/tests/test-pipe.cpp
@@ -142,3 +142,89 @@ TEST(Uvpp2Pipe, reportsStaticConnectFailureCallback) {
   loop.close();
   std::filesystem::remove(path);
 }
+
+TEST(Uvpp2Pipe, writeWithHandleSendsStreamOverIpc) {
+  auto path = pipe_path() + "-ipc";
+  std::filesystem::remove(path);
+
+  uv::loop loop;
+  uv::pipe ipc_server(loop);        // ipc=false: only accepts connections
+  uv::pipe ipc_client(loop, true);  // ipc=true: sends handles via write_with_handle
+  uv::connect_request connect_req;
+  uv::write_request write_req;
+
+  uv::tcp tcp_to_pass(loop);
+  tcp_to_pass.bind(uv::ipv4{"127.0.0.1", 0});
+
+  bool data_received   = false;
+  bool handle_received = false;
+
+  ipc_server.bind(path);
+  ipc_server.listen([&](uv::pipe &srv, uv::result status) {
+    ASSERT_TRUE(status);
+
+    auto *accepted = new uv::pipe(loop, true);
+    srv.accept(*accepted);
+    srv.close();
+
+    accepted->read_start(pipe_alloc, [&, accepted](uv::pipe &ipc, uv::read_result read) {
+      if (read.eof()) {
+        ipc.close([](uv::pipe &p) { delete &p; });
+        return;
+      }
+      ASSERT_TRUE(read.ok());
+      data_received = true;
+
+      if (ipc.pending_count() > 0) {
+        EXPECT_EQ(ipc.pending_type(), UV_TCP);
+        auto *received = new uv::tcp(loop);
+        ipc.accept(*received);
+        handle_received = true;
+        received->close([](uv::tcp &t) { delete &t; });
+      }
+
+      ipc.read_stop();
+      ipc.close([](uv::pipe &p) { delete &p; });
+    });
+  });
+
+  ipc_client.connect(connect_req, path, [&](uv::connect_request &, uv::result status) {
+    ASSERT_TRUE(status);
+    static char msg[] = "x";
+    uv::buffer_view buf{msg, 1};
+    ipc_client.write_with_handle(write_req,
+      std::span<const uv::buffer_view>{&buf, 1},
+      tcp_to_pass,
+      [&](uv::write_request &, uv::result wr) {
+        ASSERT_TRUE(wr);
+        ipc_client.close();
+        tcp_to_pass.close();
+      });
+  });
+
+  loop.run();
+
+  EXPECT_TRUE(data_received);
+  EXPECT_TRUE(handle_received);
+
+  loop.close();
+  std::filesystem::remove(path);
+}
+
+TEST(Uvpp2Pipe, writeWithHandleNowReturnsErrorOnUnconnectedPipe) {
+  uv::loop loop;
+  uv::pipe ipc(loop, true);
+  uv::tcp handle(loop);
+
+  static char msg[] = "x";
+  uv::buffer_view buf{msg, 1};
+  auto r = ipc.write_with_handle_now(std::span<const uv::buffer_view>{&buf, 1}, handle);
+
+  EXPECT_TRUE(r.has_error());
+  EXPECT_FALSE(r.ok());
+
+  ipc.close();
+  handle.close();
+  loop.run();
+  loop.close();
+}

--- a/tests/test-stream-requests.cpp
+++ b/tests/test-stream-requests.cpp
@@ -235,6 +235,7 @@ TEST(Uvpp2StreamRequests, writeNowSendsBytesOnConnectedTcp) {
 
   EXPECT_TRUE(write_ok);
   EXPECT_EQ(bytes_written, 5u);
+  EXPECT_EQ(bytes_read, 5u);
 }
 
 TEST(Uvpp2StreamRequests, writeNowReturnsErrorOnUnconnectedStream) {

--- a/tests/test-stream-requests.cpp
+++ b/tests/test-stream-requests.cpp
@@ -187,3 +187,69 @@ TEST(Uvpp2StreamRequests, immediateShutdownFailureClearsCallback) {
   loop.run();
   loop.close();
 }
+
+TEST(Uvpp2StreamRequests, writeNowSendsBytesOnConnectedTcp) {
+  uv::loop loop;
+  uv::tcp server(loop);
+  uv::tcp client(loop);
+  uv::connect_request connect_req;
+
+  std::size_t bytes_written = 0;
+  std::size_t bytes_read    = 0;
+  bool write_ok = false;
+
+  static std::array<char, 1024> read_buf{};
+  auto alloc = [](uv::tcp &, std::size_t) {
+    return uv::buffer_view{read_buf.data(), read_buf.size()};
+  };
+
+  server.bind(uv::ipv4{"127.0.0.1", 0});
+  server.listen([&](uv::tcp &srv, uv::result status) {
+    ASSERT_TRUE(status);
+    auto *accepted = new uv::tcp(loop);
+    srv.accept(*accepted);
+    srv.close();
+    accepted->read_start(alloc, [&](uv::tcp &conn, uv::read_result read) {
+      if (read.eof()) {
+        conn.close([](uv::tcp &c) { delete &c; });
+        return;
+      }
+      ASSERT_TRUE(read.ok());
+      bytes_read += static_cast<std::size_t>(read.count());
+    });
+  });
+
+  auto bound = server.sockname();
+  client.connect(connect_req, uv::ipv4{"127.0.0.1", bound.port()},
+    [&](uv::connect_request &, uv::result status) {
+      ASSERT_TRUE(status);
+      static char payload[] = "hello";
+      auto r = client.write_now(std::as_bytes(std::span{payload, 5}));
+      write_ok         = r.ok();
+      bytes_written    = r.bytes_written();
+      client.close();
+    });
+
+  loop.run();
+  loop.close();
+
+  EXPECT_TRUE(write_ok);
+  EXPECT_EQ(bytes_written, 5u);
+}
+
+TEST(Uvpp2StreamRequests, writeNowReturnsErrorOnUnconnectedStream) {
+  uv::loop loop;
+  uv::tcp tcp(loop);
+
+  static char payload[] = "test";
+  auto r = tcp.write_now(std::as_bytes(std::span{payload, 4}));
+
+  EXPECT_TRUE(r.has_error());
+  EXPECT_FALSE(r.ok());
+  EXPECT_FALSE(r.would_block());
+  EXPECT_TRUE(r.error_code());
+
+  tcp.close();
+  loop.run();
+  loop.close();
+}


### PR DESCRIPTION
- Add write_now_result type: ok(), would_block(), has_error(), bytes_written(), raw(), error_code(); UV_EAGAIN is not an error
- Add stream::write_now() x3 overloads wrapping uv_try_write
- Add pipe::write_with_handle() wrapping uv_write2 (IPC-only, on pipe)
- Add pipe::write_with_handle_now() wrapping uv_try_write2
- Move write trampoline to write_request::trampoline (shared by all write paths)
- Require native_stream() concept for SendHandle template parameter
- Add tests for all new APIs; IPC test uses ipc=false server listener (uv_pipe_listen rejects ipc=true handles) with ipc=true accepted conn